### PR TITLE
fixed vercel json to solve build error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,4 @@
 {
-  "analytics": {
-    "enable": true
-  },
-  "speedInsights": {
-    "enable": true
-  },
   "functions": {
     "app/api/**": {
       "maxDuration": 30


### PR DESCRIPTION
This commit description details the fix for the `vercel.json` schema validation error.

***

### Fix: Resolve Vercel deployment failure due to invalid `vercel.json`

This commit amends the previous changes to fix a schema validation error in the `vercel.json` file. The `analytics` and `speedInsights` properties were causing the deployment to fail because they are not valid in the top-level configuration.

- **Removed invalid properties**: The `analytics` and `speedInsights` keys have been removed, as they are managed through the Vercel dashboard and are not part of the `vercel.json` schema.
- **Enabled successful deployment**: This change ensures the `vercel.json` file is valid, allowing future deployments to proceed without error.